### PR TITLE
Turning JSON Schema validation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+# 0.0.15
+
+JSON schema validation was making things slow. We are turning it off permanently
+as the JSON is being downloaded from CDN
+
+The skip_json_validation property should only be used if the datafile is being pulled from the REST API or CDN.
+
 # 0.0.14
 
 Added a Omniture tag for tracking in erb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    optimizely_server_side (0.0.14)
+    optimizely_server_side (0.0.15)
       activesupport (~> 4.2, >= 4.2.6)
       optimizely-sdk (~> 0.1.1)
 

--- a/lib/optimizely_server_side/optimizely_sdk.rb
+++ b/lib/optimizely_server_side/optimizely_sdk.rb
@@ -11,7 +11,11 @@ module OptimizelyServerSide
       # Datafile
       def project_instance(options = {})
         Optimizely::Project.new(cached_datafile,
-                                options[:event_dispatcher])
+                                options[:event_dispatcher],
+                                nil,
+                                nil,
+                                skip_json_validation = true
+                                )
       end
 
       def cached_datafile

--- a/lib/optimizely_server_side/optimizely_sdk.rb
+++ b/lib/optimizely_server_side/optimizely_sdk.rb
@@ -14,7 +14,7 @@ module OptimizelyServerSide
                                 options[:event_dispatcher],
                                 nil,
                                 nil,
-                                skip_json_validation = true
+                                true #skip_json_validation
                                 )
       end
 

--- a/optimizely_server_side.gemspec
+++ b/optimizely_server_side.gemspec
@@ -2,8 +2,8 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'optimizely_server_side'
-  s.version     = '0.0.14'
-  s.date        = '2016-09-13'
+  s.version     = '0.0.15'
+  s.date        = '2016-09-14'
   s.summary     = "Optimizely server side. A wrapper on top of optimizely's ruby sdk for easy caching of server side config "
   s.description = "Optimizely server side. A A/B test wrapper on top of optimizely's ruby sdk for easy caching of server side config and exposing few more utility helpers. Handling of fallbacks and marking primary experiments. "
   s.authors     = ["Ankit Gupta"]


### PR DESCRIPTION
JSON schema validation was slow.

_Note_: `method_with_oss` is the server side method.

Before

```
irb(main):001:0> CheckOss.new.bm_ips
Warming up --------------------------------------
     method_with_oss     4.000  i/100ms
       method_simple    18.000  i/100ms
     method_with_sdk     9.000  i/100ms
Calculating -------------------------------------
     method_with_oss     76.030  (±10.5%) i/s -    376.000  in   5.017558s
       method_simple    181.503  (± 5.5%) i/s -    918.000  in   5.073438s
     method_with_sdk     96.141  (± 6.2%) i/s -    486.000  in   5.073778s

Comparison:
       method_simple:      181.5 i/s
     method_with_sdk:       96.1 i/s - 1.89x  slower
     method_with_oss:       76.0 i/s - 2.39x  slower
```


After

```
irb(main):001:0> CheckOss.new.bm_ips
Warming up --------------------------------------
     method_with_oss    13.000  i/100ms
       method_simple    18.000  i/100ms
     method_with_sdk     9.000  i/100ms
Calculating -------------------------------------
     method_with_oss    166.506  (± 6.0%) i/s -    832.000  in   5.015433s
       method_simple    182.783  (± 5.5%) i/s -    918.000  in   5.037205s
     method_with_sdk     95.030  (± 6.3%) i/s -    477.000  in   5.037860s

Comparison:
       method_simple:      182.8 i/s
     method_with_oss:      166.5 i/s - same-ish: difference falls within error
     method_with_sdk:       95.0 i/s - 1.92x  slower

```