### PR TITLE
Optimizely SDK Version Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.2
   - 2.3.0
+  - 2.4.0
 script: bundle exec rspec spec
 addons:
   code_climate:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,14 +3,14 @@ PATH
   specs:
     optimizely_server_side (1.2.1)
       activesupport (>= 4.2.6)
-      optimizely-sdk (~> 1.4)
+      optimizely-sdk (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.1.4)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.5.1)
@@ -23,17 +23,17 @@ GEM
     diff-lcs (1.3)
     docile (1.1.5)
     hashdiff (0.3.2)
-    httparty (0.15.6)
+    httparty (0.16.2)
       multi_xml (>= 0.5.2)
-    i18n (0.9.0)
+    i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
-    minitest (5.10.3)
+    minitest (5.11.3)
     multi_xml (0.6.0)
     murmurhash3 (0.1.6)
-    optimizely-sdk (1.4.0)
+    optimizely-sdk (2.0.1)
       httparty (~> 0.11)
       json-schema (~> 2.6)
       murmurhash3 (~> 0.1)
@@ -58,7 +58,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     webmock (2.3.2)
       addressable (>= 2.3.6)
@@ -75,4 +75,4 @@ DEPENDENCIES
   webmock (~> 2.1)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    optimizely_server_side (1.2.1)
+    optimizely_server_side (1.2.2)
       activesupport (>= 4.2.6)
       optimizely-sdk (~> 2.0)
 

--- a/optimizely_server_side.gemspec
+++ b/optimizely_server_side.gemspec
@@ -2,8 +2,8 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'optimizely_server_side'
-  s.version     = '1.2.1'
-  s.date        = '2017-11-13'
+  s.version     = '1.2.2'
+  s.date        = '2018-05-22'
   s.summary     = "Optimizely server side. A wrapper on top of optimizely's ruby sdk for easy caching of server side config "
   s.description = "Optimizely server side. A A/B test wrapper on top of optimizely's ruby sdk for easy caching of server side config and exposing few more utility helpers. Handling of fallbacks and marking primary experiments. "
   s.authors     = ["Ankit Gupta"]
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'webmock', '~> 2.1'
-  s.add_runtime_dependency 'optimizely-sdk' , '~> 1.4'
+  s.add_runtime_dependency 'optimizely-sdk' , '~> 2.0'
   s.add_runtime_dependency 'activesupport', '>= 4.2.6'
 end


### PR DESCRIPTION
Optimizely SDK version bump to `~> 2.0` (latest is `2.0.1`)